### PR TITLE
chore(ci): replace mirror.yml with reusable wrapper

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,104 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0-or-later
-name: Mirror to GitLab and Bitbucket
+name: Mirror to Git Forges
 
 on:
   push:
-    branches: [main, master]
-    tags:
-      - 'v*'
+    branches: [main]
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
-  mirror-gitlab:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    if: ${{ vars.GITLAB_MIRROR_ENABLED == 'true' }}
-
-    steps:
-      - name: Check SSH key configured
-        id: check-key
-        env:
-          SSH_KEY: ${{ secrets.GITLAB_SSH_KEY }}
-        run: |
-          if [ -z "$SSH_KEY" ]; then
-            echo "::warning::GITLAB_SSH_KEY secret not configured. Skipping GitLab mirror."
-            echo "configured=false" >> $GITHUB_OUTPUT
-          else
-            echo "configured=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout
-        if: steps.check-key.outputs.configured == 'true'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup SSH
-        if: steps.check-key.outputs.configured == 'true'
-        uses: webfactory/ssh-agent@a6f90b1f127823b31c7c27b366ef5d486f4fe3c1 # v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
-
-      - name: Add GitLab to known hosts
-        if: steps.check-key.outputs.configured == 'true'
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -t ed25519 gitlab.com >> ~/.ssh/known_hosts
-
-      - name: Push to GitLab
-        if: steps.check-key.outputs.configured == 'true'
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          git remote add gitlab git@gitlab.com:hyperpolymath/${REPO_NAME}.git || true
-          git push gitlab HEAD:main --force || git push gitlab HEAD:master --force
-          git push gitlab --tags --force
-
-  mirror-bitbucket:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    if: ${{ vars.BITBUCKET_MIRROR_ENABLED == 'true' }}
-
-    steps:
-      - name: Check SSH key configured
-        id: check-key
-        env:
-          SSH_KEY: ${{ secrets.BITBUCKET_SSH_KEY }}
-        run: |
-          if [ -z "$SSH_KEY" ]; then
-            echo "::warning::BITBUCKET_SSH_KEY secret not configured. Skipping Bitbucket mirror."
-            echo "configured=false" >> $GITHUB_OUTPUT
-          else
-            echo "configured=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout
-        if: steps.check-key.outputs.configured == 'true'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup SSH
-        if: steps.check-key.outputs.configured == 'true'
-        uses: webfactory/ssh-agent@a6f90b1f127823b31c7c27b366ef5d486f4fe3c1 # v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.BITBUCKET_SSH_KEY }}
-
-      - name: Add Bitbucket to known hosts
-        if: steps.check-key.outputs.configured == 'true'
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -t ed25519 bitbucket.org >> ~/.ssh/known_hosts
-
-      - name: Push to Bitbucket
-        if: steps.check-key.outputs.configured == 'true'
-        env:
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          git remote add bitbucket git@bitbucket.org:hyperpolymath/${REPO_NAME}.git || true
-          git push bitbucket HEAD:main --force || git push bitbucket HEAD:master --force
-          git push bitbucket --tags --force
+  mirror:
+    uses: hyperpolymath/standards/.github/workflows/mirror-reusable.yml@e6b2884722350515934d443daf23442f2195796f
+    secrets: inherit


### PR DESCRIPTION
## Summary
Replaces this repo's full `mirror.yml` (~145 lines, drift-prone) with a thin ~13-line wrapper that calls `hyperpolymath/standards/.github/workflows/mirror-reusable.yml@e6b2884722350515934d443daf23442f2195796f` (merged via standards#187).

Forge selection (GitLab, Bitbucket, Codeberg, SourceHut, Disroot, Gitea, Radicle) remains gated by Actions `vars.<FORGE>_MIRROR_ENABLED` exactly as before. `secrets: inherit` flows the per-forge SSH keys through implicitly.

## Why
Estate audit: 289 `mirror.yml` deployments across the org, 75 unique blob SHAs (76% drift). Drift is action-SHA pin churn, not feature variance — the canonical 7-forge job set is identical across sampled variants. Converging behind the reusable cuts ~94k LOC of estate scaffold and means future changes to mirror logic propagate via one SHA bump.

Part of estate-wide convergence campaign 2026-05-26 (standards#199 / #187).