### PR TITLE
docs(claude-md): flip ReScript→AffineScript per 2026-05-25 estate language policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,14 +19,14 @@ The following files in `.machine_readable/` contain structured project metadata:
 
 | Language/Tool | Use Case | Notes |
 |---------------|----------|-------|
-| **ReScript** | Primary application code | Compiles to JS, type-safe |
+| **AffineScript** | Primary application code | Affine-typed, compiles to typed-wasm or Deno-ESM |
 | **Deno** | Runtime & package management | Replaces Node/npm/bun |
 | **Rust** | Performance-critical, systems, WASM | Preferred for CLI tools |
 | **Tauri 2.0+** | Mobile apps (iOS/Android) | Rust backend + web UI |
 | **Dioxus** | Mobile apps (native UI) | Pure Rust, React-like |
 | **Gleam** | Backend services | Runs on BEAM or compiles to JS |
 | **Bash/POSIX Shell** | Scripts, automation | Keep minimal |
-| **JavaScript** | Only where ReScript cannot | MCP protocol glue, Deno APIs |
+| **JavaScript** | Only where AffineScript cannot | MCP protocol glue, Deno APIs |
 | **Python** | SaltStack only | No other Python permitted |
 | **Nickel** | Configuration language | For complex configs |
 | **Guile Scheme** | State/meta files | STATE.scm, META.scm, ECOSYSTEM.scm |
@@ -38,7 +38,7 @@ The following files in `.machine_readable/` contain structured project metadata:
 
 | Banned | Replacement |
 |--------|-------------|
-| TypeScript | ReScript |
+| TypeScript | AffineScript |
 | Node.js | Deno |
 | npm | Deno |
 | Bun | Deno |
@@ -54,14 +54,14 @@ The following files in `.machine_readable/` contain structured project metadata:
 
 **No exceptions for Kotlin/Swift** - use Rust-first approach:
 
-1. **Tauri 2.0+** - Web UI (ReScript) + Rust backend, MIT/Apache-2.0
+1. **Tauri 2.0+** - Web UI (AffineScript) + Rust backend, MIT/Apache-2.0
 2. **Dioxus** - Pure Rust native UI, MIT/Apache-2.0
 
 Both are FOSS with independent governance (no Big Tech).
 
 ### Enforcement Rules
 
-1. **No new TypeScript files** - Convert existing TS to ReScript
+1. **No new TypeScript files** - Convert existing TS to AffineScript
 2. **No package.json for runtime deps** - Use deno.json imports
 3. **No node_modules in production** - Deno caches deps automatically
 4. **No Go code** - Use Rust instead


### PR DESCRIPTION
Per the 2026-05-25 estate language policy
([standards#252](https://github.com/hyperpolymath/standards/issues/252)),
the `.claude/CLAUDE.md` language-policy table in this repo named ReScript
as the primary application language and as the TypeScript replacement.
Flip both to AffineScript via the same 6-line template substitution used
in the dev-eco/phronesis/dotfiles initial sweep.

## Substitutions applied

1. `**ReScript** | Primary application code | Compiles to JS, type-safe`
   → `**AffineScript** | Primary application code | Affine-typed, compiles to typed-wasm or Deno-ESM`
2. `Only where ReScript cannot` → `Only where AffineScript cannot`
3. `| TypeScript | ReScript |` (BANNED replacement) → `| TypeScript | AffineScript |`
4. `Web UI (ReScript)` → `Web UI (AffineScript)`
5. `Convert existing TS to ReScript` → `Convert existing TS to AffineScript`
6. `ReScript for apps` → `AffineScript for apps`

## Scope check (template-clone class)

This repo was categorised in the 2026-05-30 100-repo survey as a
**template-clone** or **template-clone-with-stubs** — meaning the
CLAUDE.md is a generic policy template clone rather than describing
ReScript-heavy local reality. Repos with substantive ReScript source
(≥5 `.res` files) were deferred to per-repo review per the
`panll`-precedent (panll#60 closed because the local reality didn't
match a wholesale flip).

Docs-only — no source changes. No CI runs are expected to fail on
behaviour grounds; if any do, that is unrelated tech debt to surface
separately.

Refs hyperpolymath/standards#287 (CLAUDE.md docs slice umbrella)
Refs hyperpolymath/standards#252 (parent ReScript→AffineScript tracker)