### PR TITLE
fix(ci): replace fake action SHA pins (niche-actions estate sweep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Alire
-        uses: alire-project/setup-alire@b1456c6fce8e775b2e1260be8a929d15d1e7f3c5 # v3.0.2
+        uses: alire-project/setup-alire@dee17535afebb29c4557f91f16a96a42f1369189 # v3.0.2
 
       - name: Build Ada TUI
         run: cd tui && alr build

--- a/.github/workflows/comprehensive-quality.yml
+++ b/.github/workflows/comprehensive-quality.yml
@@ -45,7 +45,7 @@ jobs:
           fi
           # Note: Python is banned per RSR - use Julia/Rust/ReScript instead
       - name: SAST scan
-        uses: returntocorp/semgrep-action@713efdd345f3b9c89a9cf549853899f828e79666
+        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d
         continue-on-error: true
 
   # INTEROPERABILITY - API and format compatibility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Generate changelog
         id: changelog
-        uses: orhun/git-cliff-action@4a4a951bc43fbbe322c2a88b5481dc1e94336522 # v4.4.2
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.4.2
         with:
           config: cliff.toml
           args: --latest --strip header


### PR DESCRIPTION
Estate fake-SHA sweep — niche actions (round-3). Version-faithful where possible; bumped to nearest in-major where the version comment itself was hallucinated. All real SHAs verified via `gh api`.

See `project_estate_fake_action_sha_punch_list_2026_05_30` for substitution map.